### PR TITLE
Use a PAT when auto merging PRs

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -13,8 +13,7 @@ on:
 
 permissions:
   id-token: write
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   verify-frontend:
@@ -95,4 +94,4 @@ jobs:
       - run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.PAT_AUTO_MERGE }}


### PR DESCRIPTION
If not, other workflows won't be triggered.